### PR TITLE
Change the CI

### DIFF
--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -30,11 +30,17 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
 
+    - name: Setup binutils branch
+      id: setup-vars
+      run: |
+        BINUTILS_BRANCH=${{ github.event.inputs.branch }}
+        echo "::set-output binutils-branch=value::${BINUTILS_BRANCH:-"${{ github.event.inputs.branch.default }}"}"
+
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: harmstone
+        ref: ${{ steps.setup-vars.outputs.binutils-branch}}
         path: binutils-gdb
   
     - name: Checkout repository

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -15,23 +15,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install dependencies
+      run: | 
+        sudo apt-get update
+        sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
+
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
         ref: master
-
-    - name: Install dependencies
-      run: | 
-        sudo apt-get update
-        sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
   
     - name: Configure
       run: |
         mkdir build
         cd build
         ../configure --target=aarch64-pe
-        pwd
         make -j8
       
     - name: Build

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build, test, create artifact
-    runs-on: [self-hosted, Windows, ARM64]
+    runs-on: [self-hosted, Windows, ARM64, GCC]
     needs: build-binutils
 
     steps:
@@ -77,7 +77,8 @@ jobs:
         name: obj-file
 
     - name: Link object file
-      run: LINK con-app-aarch64.o kernel32.Lib /SUBSYSTEM:CONSOLE
+      run: |
+        C:\Program` Files\Git\bin\bash.exe .github\workflows\scripts\link.sh
 
     - name: Dumpbin the executable
       run: DUMPBIN /HEADERS .\con-app-aarch64.exe

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -46,9 +46,8 @@ jobs:
 
     - name: Configure and build
       run: |
-        cd binutils-gdb
-        mkdir build
-        cd build
+        mkdir -p binutils-gdb/build
+        cd binutils-gdb/build
         ../configure --target=aarch64-pe --prefix="$HOME/cross"
         make -j$(nproc)
     
@@ -79,9 +78,6 @@ jobs:
     - name: Link object file
       run: |
         C:\Program` Files\Git\bin\bash.exe .github\workflows\scripts\link.sh
-
-    - name: Dumpbin the executable
-      run: DUMPBIN /HEADERS .\con-app-aarch64.exe
 
     - name: Upload executable
       uses: actions/upload-artifact@v3

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -2,6 +2,16 @@ name: Minimal console app build
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name'
+        type: option
+        default: harmstone
+        options:
+          - harmstone
+          - master
+          - aarch64-pe-dev
+          - aarch64-pe-zac
   pull_request:
     paths-ignore:
       - '**/*.md'
@@ -24,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: harmstone
+        ref: ${{ inputs.branch }}
   
     - name: Configure and build
       run: |
@@ -42,19 +52,16 @@ jobs:
       run: |
         cd min-con-app-source
         ./../build/gas/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
-    - name: Test
-      run: |
-        ls
-        echo "--------"
-        ls ../build/gas/
-        echo "--------"
-        ls ./min-exe
-        
+
+    - run: ls
+    - run: ls ./../build/gas/
+    - run: ls ./min-exe/
+
     - name: Upload object file
       uses: actions/upload-artifact@v3
       with:
         name: obj-file
-        path: con-app-aarch64.o  
+        path: ./con-app-aarch64.o  
 
   build:
     name: Build, test, create artifact

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -19,6 +19,9 @@ on:
     paths-ignore:
       - '**/*.md'
 
+env:
+  default_branch: harmstone  
+
 jobs:
   build-binutils:
     name: Build binutils and create object file
@@ -34,7 +37,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: ${{ inputs.branch || inputs.branch.default }}
+        ref: ${{ inputs.branch || env.default_branch }}
         path: binutils-gdb
   
     - name: Checkout repository

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         mkdir build
         cd build
-       ../configure --target=aarch64-pe --prefix="$HOME/cross"
+        ../configure --target=aarch64-pe --prefix="$HOME/cross"
       
     - name: Build
       run: make -j8

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -35,13 +35,16 @@ jobs:
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
         ref: harmstone
+        path: binutils-gdb
   
     - name: Configure and build
       run: |
+        cd binutils-gdb
         mkdir build
         cd build
         ../configure --target=aarch64-pe --prefix="$HOME/cross"
         make -j8
+        cd ../../
 
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -50,12 +53,7 @@ jobs:
     
     - name: Create object file
       run: |
-        cd min-con-app-source
-        ./../build/gas/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
-
-    - run: ls
-    - run: ls ./../build/gas/
-    - run: ls ./min-exe/
+        ./binutils-gdb/build/gas/as-new ./min-con-app-source/min-exe/con-app-aarch64.s -o con-app-aarch64.o  
 
     - name: Upload object file
       uses: actions/upload-artifact@v3

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -34,7 +34,7 @@ jobs:
       id: setup-vars
       run: |
         BINUTILS_BRANCH=${{ github.event.inputs.branch }}
-        echo "binutils-branch=${BINUTILS_BRANCH:-"${{ github.event.inputs.branch.default }}"" >> $GITHUB_OUTPUT
+        echo "binutils-branch=${BINUTILS_BRANCH:-${{ github.event.inputs.branch.default }}" >> $GITHUB_OUTPUT
 
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -42,7 +42,14 @@ jobs:
       run: |
         cd min-con-app-source
         ./../build/gas/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
-
+    - name: Test
+      run: |
+        ls
+        echo "--------"
+        ls ../build/gas/
+        echo "--------"
+        ls ./min-exe
+        
     - name: Upload object file
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -37,6 +37,11 @@ jobs:
         ref: harmstone
         path: binutils-gdb
   
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        path: min-con-app-source
+
     - name: Configure and build
       run: |
         cd binutils-gdb
@@ -45,11 +50,6 @@ jobs:
         ../configure --target=aarch64-pe --prefix="$HOME/cross"
         make -j8
         cd ../../
-
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        path: min-con-app-source
     
     - name: Create object file
       run: |

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -31,6 +31,8 @@ jobs:
         mkdir build
         cd build
         ../configure --target=aarch64-pe
+        pwd
+        make -j8
       
     - name: Build
       run: make -j8

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -26,15 +26,12 @@ jobs:
         repository: Windows-on-ARM-Experiments/binutils-gdb
         ref: master
   
-    - name: Configure
+    - name: Configure and build
       run: |
         mkdir build
         cd build
         ../configure --target=aarch64-pe
         make -j8
-      
-    - name: Build
-      run: make -j8
 
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -20,6 +20,11 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
 
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        path: min-con-app-source
+
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3
       with:
@@ -33,11 +38,6 @@ jobs:
         ../configure --target=aarch64-pe
         make -j8
 
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        path: min-con-app-source
-    
     - name: Create object file
       run: |
         cd min-con-app-source

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -10,16 +10,58 @@ on:
       - '**/*.md'
 
 jobs:
+  build-binutils:
+    name: Build binutils and create object file
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download binutils-gdb source code
+      uses: actions/checkout@v3
+      with:
+        repository: Windows-on-ARM-Experiments/binutils-gdb
+
+    - name: Install dependencies
+      run: | 
+        sudo apt-get update
+        sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
+  
+    - name: Configure
+      run: |
+        mkdir build
+        cd build
+       ../configure --target=aarch64-pe --prefix="$HOME/cross"
+      
+    - name: Build
+      run: make -j8
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        path: min-con-app
+    
+    - name: Create object file
+      run: |
+        ./../build/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
+
+    - name: Upload object file
+      uses: actions/upload-artifact@v3
+      with:
+        name: obj-file
+        path: con-app-aarch64.o  
+
   build:
     name: Build, test, create artifact
     runs-on: [self-hosted, Windows, ARM64]
+    needs: build-binutils
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Create object file
-      run: .\tools\as.exe .\min-exe\con-app-aarch64.s -o con-app-aarch64.o
+    - name: Download object file
+      uses: actions/download-artifact@v3
+      with:
+        name: obj-file
 
     - name: Link object file
       run: LINK con-app-aarch64.o kernel32.Lib /SUBSYSTEM:CONSOLE

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -36,10 +36,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        path: min-con-app
+        path: min-con-app-source
     
     - name: Create object file
       run: |
+        cd min-con-app-source
         ./../build/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
 
     - name: Upload object file

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
+        ref: master
 
     - name: Install dependencies
       run: | 
@@ -29,7 +30,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        ../configure --target=aarch64-pe --prefix="$HOME/cross"
+        ../configure --target=aarch64-pe
       
     - name: Build
       run: make -j8

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -5,12 +5,7 @@ on:
     inputs:
       branch:
         description: 'Branch name'
-        type: choice
-        options:
-          - harmstone
-          - master
-          - aarch64-pe-dev
-          - aarch64-pe-zac
+        type: string
   pull_request:
     paths-ignore:
       - '**/*.md'
@@ -19,7 +14,7 @@ on:
       - '**/*.md'
 
 env:
-  default_branch: harmstone  
+  default_branch: aarch64-pe-dev 
 
 jobs:
   build-binutils:

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -1,6 +1,7 @@
 name: Minimal console app build
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - '**/*.md'
@@ -10,8 +11,8 @@ on:
 
 jobs:
   build:
-    name: Build and upload minimal console app
-    runs-on: windows-latest
+    name: Build, test, create artifact
+    runs-on: [self-hosted, Windows, ARM64]
 
     steps:
     - name: Checkout repository
@@ -19,18 +20,6 @@ jobs:
 
     - name: Create object file
       run: .\tools\as.exe .\min-exe\con-app-aarch64.s -o con-app-aarch64.o
-
-    # # Uncomment in case there will be an issue with path overwrite by git/usr/bin/link
-    # - name: Remove /usr/bin/link
-    #   run: |
-    #     $Remove = 'C:\Program Files\Git\usr\bin'
-    #     $env:Path = ($env:Path.Split(';') | Where-Object -FilterScript {$_ -ne $Remove}) -join ';'
-    #     $env:PATH
-
-    - name: Configure build for arm64
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: amd64_arm64
 
     - name: Link object file
       run: LINK con-app-aarch64.o kernel32.Lib /SUBSYSTEM:CONSOLE
@@ -44,25 +33,8 @@ jobs:
         name: min-console-exe
         path: .\con-app-aarch64.exe
 
-
-  test:
-    name: Run and assert the output of app run
-    runs-on: [self-hosted, Windows, ARM64]
-    needs: build
-    
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Download a single artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: min-console-exe
-    
     - name: Run minimal console app
       run: .\con-app-aarch64.exe
-
+    
     - name: Run assert script
       run: .\.github\workflows\scripts\assert-output.ps1
-
-

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -20,11 +20,6 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
 
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        path: min-con-app-source
-
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3
       with:
@@ -38,10 +33,15 @@ jobs:
         ../configure --target=aarch64-pe
         make -j8
 
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        path: min-con-app-source
+    
     - name: Create object file
       run: |
         cd min-con-app-source
-        ./../build/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
+        ./../build/gas/as-new ./min-exe/con-app-aarch64.s -o con-app-aarch64.o  
 
     - name: Upload object file
       uses: actions/upload-artifact@v3

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: ${{ github.event.inputs.branch || github.event.inputs.branch.default }}
+        ref: ${{ inputs.branch || inputs.branch.default }}
         path: binutils-gdb
   
     - name: Checkout repository

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: master
+        ref: harmstone
   
     - name: Configure and build
       run: |

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -30,17 +30,11 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install build-essential binutils-for-build texinfo bison flex zlib1g-dev libgmp-dev dejagnu libmpfr-dev
 
-    - name: Setup binutils branch
-      id: setup-vars
-      run: |
-        BINUTILS_BRANCH=${{ github.event.inputs.branch }}
-        echo "binutils-branch=${BINUTILS_BRANCH:-${{ github.event.inputs.branch.default }}" >> $GITHUB_OUTPUT
-
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: ${{ steps.setup-vars.outputs.binutils-branch}}
+        ref: ${{ github.event.inputs.branch || github.event.inputs.branch.default }}
         path: binutils-gdb
   
     - name: Checkout repository

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -34,7 +34,7 @@ jobs:
       id: setup-vars
       run: |
         BINUTILS_BRANCH=${{ github.event.inputs.branch }}
-        echo "::set-output binutils-branch=value::${BINUTILS_BRANCH:-"${{ github.event.inputs.branch.default }}"}"
+        echo "binutils-branch=${BINUTILS_BRANCH:-"${{ github.event.inputs.branch.default }}"" >> $GITHUB_OUTPUT
 
     - name: Download binutils-gdb source code
       uses: actions/checkout@v3

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: Windows-on-ARM-Experiments/binutils-gdb
-        ref: ${{ inputs.branch }}
+        ref: harmstone
   
     - name: Configure and build
       run: |

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -5,8 +5,7 @@ on:
     inputs:
       branch:
         description: 'Branch name'
-        type: option
-        default: harmstone
+        type: choice
         options:
           - harmstone
           - master

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        ../configure --target=aarch64-pe
+        ../configure --target=aarch64-pe --prefix="$HOME/cross"
         make -j8
 
     - name: Checkout repository

--- a/.github/workflows/minimal-console.yml
+++ b/.github/workflows/minimal-console.yml
@@ -50,8 +50,7 @@ jobs:
         mkdir build
         cd build
         ../configure --target=aarch64-pe --prefix="$HOME/cross"
-        make -j8
-        cd ../../
+        make -j$(nproc)
     
     - name: Create object file
       run: |

--- a/.github/workflows/scripts/link.sh
+++ b/.github/workflows/scripts/link.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -ex # stop bash script on error
+
+research_dir=$(pwd)
+
+cd "C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC"
+cd $(ls -d */|tail -n 1)
+cd ./bin/Hostarm64/arm64/
+link_exe_path=$(pwd)/link.exe
+
+cd "C:\Program Files (x86)\Windows Kits\10\Lib"
+cd $(ls -d */|tail -n 1)
+cd ./um/arm64/
+kernel32_path=$(pwd)/kernel32.Lib
+
+cd $research_dir
+
+"$link_exe_path" con-app-aarch64.o "$kernel32_path" /SUBSYSTEM:CONSOLE


### PR DESCRIPTION
Current PR uses [binutils](https://github.com/Windows-on-ARM-Experiments/binutils-gdb) repo for creating GAS, which will be used later to create an object file for minimal console app. You can also dispatch workflow manually with a different branch (by default it is harmstone branch). There are two artefacts created during the workflow - `obj-file` (which is a `con-app-aarch64.o`) and `min-console-exe` (final executable)